### PR TITLE
User Roles

### DIFF
--- a/app/charges/charges_response.py
+++ b/app/charges/charges_response.py
@@ -13,3 +13,4 @@ class Response():
 	InvalidPriority = {'error': 'Invalid priority level.'}
 	EditError = {'error': 'Couldn\'t edit charge.'}
 	EditSuccess = {'success': 'Charge successfully edited.'}
+	PermError = {'error': 'Insufficient permissions to perform this action.'}

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -26,6 +26,7 @@ from app.users.models import Users
 def get_all_charges(broadcast = False):
 
     charges = Charges.query.filter_by().all()
+    charge_ser = []
 
     for charge in charges:
         if charge.private:

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -16,8 +16,7 @@ from app.users.models import Users
 
 
 ##
-## @brief      Gets the charges of all committees
-##             a user is part of.
+## @brief      Gets all public charges.
 ##
 ## @param      broadcast  The broadcast
 ##
@@ -27,19 +26,21 @@ from app.users.models import Users
 def get_all_charges(broadcast = False):
 
     charges = Charges.query.filter_by().all()
-    charge_ser = [
-                    {
-                        "id": charge.id,
-                        "title": charge.title,
-                        "description": charge.description,
-                        "committee": charge.committee,
-                        "priority": charge.priority,
-                        "status": charge.status,
-                        "paw_links": charge.paw_links,
-                        "created_at": charge.created_at.isoformat()
-                    }
-                    for charge in charges
-                ]
+
+    for charge in charges:
+        if charge.private:
+            continue;
+
+        charge_ser.append({
+            "id": charge.id,
+            "title": charge.title,
+            "description": charge.description,
+            "committee": charge.committee,
+            "priority": charge.priority,
+            "status": charge.status,
+            "paw_links": charge.paw_links,
+            "created_at": charge.created_at.isoformat()
+        });
     emit("get_all_charges", charge_ser, broadcast = broadcast)
 
 
@@ -78,6 +79,7 @@ def get_charges(user, user_data, broadcast = False):
             "priority": charge.priority,
             "status": charge.status,
             "paw_links": charge.paw_links,
+            "private": charge.private,
             "created_at": charge.created_at.isoformat()
         });
     emit("get_charges", charge_ser, broadcast = broadcast)
@@ -119,6 +121,7 @@ def get_charge(user, user_data, broadcast = False):
         "priority": charge.priority,
         "status": charge.status,
         "paw_links": charge.paw_links,
+        "private": charge.private,
         "created_at": charge.created_at.isoformat()
     }
     emit('get_charge', charge_info, broadcast= broadcast)

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -201,7 +201,7 @@ def create_charge(user, user_data):
     try:
         db.session.commit()
         emit('create_charge', Response.AddSuccess)
-        get_charges(committee.id, broadcast= True)
+        get_charges(user_data, broadcast= True)
     except Exception as e:
         db.session.rollback()
         db.session.flush()
@@ -264,10 +264,8 @@ def edit_charge(user, user_data):
         # Send successful edit notification to user
         # and broadcast charge changes.
         emit("edit_charge", Response.EditSuccess)
-        print(user_data)
         get_charge(user_data, broadcast= True)
-        get_charges(charge.committee, broadcast= True)
+        get_charges(user_data, broadcast= True)
     except Exception as e:
-        print(e)
         db.session.rollback()
         emit("edit_charge", Response.EditError)

--- a/app/charges/models.py
+++ b/app/charges/models.py
@@ -28,3 +28,4 @@ class Charges(db.Model):
     paw_links = db.Column(db.String)
     priority = db.Column(db.Integer)
     status = db.Column(db.Integer)
+    private = db.Column(db.Boolean)

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -124,7 +124,8 @@ class TestCharges(object):
             "title": "test charge",
             "priority": 0,
             "description": "test description",
-            "committee": "testcommittee"
+            "committee": "testcommittee",
+            "private": True
         }
 
         self.socketio.emit('create_charge', user_data)
@@ -143,6 +144,20 @@ class TestCharges(object):
         self.socketio.emit('create_charge', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.AddSuccess
+
+    def test_create_charge_no_permission(self):
+        user_data = {
+            "token": self.user_token2,
+            "title": "test charge",
+            "priority": 0,
+            "description": "test description",
+            "committee": "testcommittee"
+        }
+
+        self.socketio.emit('create_charge', user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
+
 
     # Test when a charge is created with no committee
     def test_create_charge_no_committee(self):

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -117,6 +117,7 @@ class TestCharges(object):
             'committee': 'testcommittee',
             'status': 0,
             'priority': 0,
+            'private': True,
             'paw_links': "https://testlink.com"
         }
 

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -129,6 +129,7 @@ class TestCharges(object):
         charge.paw_links = "https://testlink.com"
         charge.priority = 0
         charge.status = 0
+        charge.private  = True
         self.charge = charge
 
         db.session.add(charge)
@@ -272,21 +273,55 @@ class TestCharges(object):
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.PermError
 
-    # Test getting a charge
+    # Test getting a charge being a member.
     def test_get_charge(self):
 
-        self.socketio.emit('get_charge', 10)
+        user_data = {
+            "token": self.user_token3,
+            "charge": 10
+        }
+
+        self.socketio.emit('get_charge', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == self.charge_dict
+
+    # Test getting a charge being an admin.
+    def test_get_charge(self):
+
+        user_data = {
+            "token": self.admin_token,
+            "charge": 10
+        }
+
+        self.socketio.emit('get_charge', user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == self.charge_dict
+
+    # Test getting charge no permissions.
+    def test_get_charge_noperm(self):
+
+        user_data = {
+            "token": self.user_token2,
+            "charge": 10
+        }
+
+        self.socketio.emit('get_charge', user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
 
     # Test getting a charge that doesn't exist
     def test_get_charge_doesnt_exist(self):
 
-        self.socketio.emit('get_charge', 99999)
+        user_data = {
+            "token": self.user_token,
+            "charge": 99999
+        }
+
+        self.socketio.emit('get_charge', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.UsrChargeDontExist
 
-        # Test getting a charge
+    # Test getting a charge
     def test_get_charges(self):
         response_data = [ self.charge_dict ]
 

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -359,6 +359,12 @@ class TestCharges(object):
         received = self.socketio.get_received()
         assert received[0]["args"][0] == []
 
+    # Get all public charges.
+    def test_get_all_charges(self):
+        self.socketio.emit('get_all_charges')
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == []
+
     def test_edit_charge(self):
 
         user_data = {

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -325,14 +325,36 @@ class TestCharges(object):
     def test_get_charges(self):
         response_data = [ self.charge_dict ]
 
-        self.socketio.emit('get_charges', "testcommittee")
+        user_data = {
+            "token": self.user_token3,
+            "committee_id": "testcommittee",
+        }
+
+        self.socketio.emit('get_charges', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == response_data
+
+    # Test getting a charge not member
+    def test_get_charges_not_member(self):
+
+        user_data = {
+            "token": self.user_token2,
+            "committee_id": "testcommittee",
+        }
+
+        self.socketio.emit('get_charges', user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == []
 
     # Test getting a charge that doesn't exist
     def test_get_charges_doesnt_exist(self):
 
-        self.socketio.emit('get_charges', "test")
+        user_data = {
+            "token": self.user_token3,
+            "committee_id": "test",
+        }
+
+        self.socketio.emit('get_charges', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == []
 

--- a/app/committees/controllers.py
+++ b/app/committees/controllers.py
@@ -55,7 +55,7 @@ def get_permissions(user, user_data):
             elif user.id == committee.head:
 
                 permission_level = Permissions.CanCreate
-            elif user in committee.members:
+            elif committee.members.filter_by(member= user).first():
 
                 permission_level = Permissions.CanContribute
         emit('get_permissions', permission_level)

--- a/app/committees/models.py
+++ b/app/committees/models.py
@@ -5,7 +5,6 @@ created by: Omar De La Hoz (oed7416@rit.edu)
 created on: 08/31/17
 """
 from app import db
-from app.members.models import members_table
 
 class Committees(db.Model):
     __tablename__ = 'committees'
@@ -18,4 +17,4 @@ class Committees(db.Model):
     meeting_time = db.Column(db.String(4))   # In the format of "1300" for 1:00PM
     meeting_day = db.Column(db.Integer)      # Where 0-Sunday and 6-Saturday
     enabled = db.Column(db.Boolean, default= True)
-    members = db.relationship('Users', secondary= members_table, back_populates="committees")
+    #members = db.relationship('Members', back_populates="committee")

--- a/app/committees/test_committees.py
+++ b/app/committees/test_committees.py
@@ -11,6 +11,7 @@ from app import app, db, socketio
 from app.committees.committees_response import Response
 from app.committees.models import Committees
 from app.users.permissions import Permissions
+from app.members.models import Members, Roles
 from app.users.models import Users
 from app.notifications.controllers import new_committee
 from flask_socketio import SocketIOTestClient
@@ -302,7 +303,9 @@ class TestCommittees(object):
         db.session.add(testcomm)
         db.session.commit()
 
-        testcomm.members.append(self.test_user)
+        membership = Members(role= Roles.NormalMember)
+        membership.member = self.test_user
+        testcomm.members.append(membership)
 
         user_data = {
             "token": self.user_token,

--- a/app/members/members_response.py
+++ b/app/members/members_response.py
@@ -14,3 +14,6 @@ class Response():
 	RemoveSuccess = {"success": "Member has been removed from committee."}
 	RemoveError = {"error": "Member couldn't be removed from committee."}
 	PermError = {"error": "User doesn't have permissions to remove members."}
+	RoleDoesntExist = {"error": "Role doesnt exist."}
+	EditSuccess = {"error": "Role successfuly edited."}
+	EditError = {"error": "Role couldn't be edited."}

--- a/app/members/models.py
+++ b/app/members/models.py
@@ -6,10 +6,20 @@ created on: 08/31/17
 """
 
 from app import db
+from enum import Enum
+from sqlalchemy_utils import ChoiceType
 from itsdangerous import (TimedJSONWebSignatureSerializer
                           as Serializer, BadSignature, SignatureExpired)
 
-members_table = db.Table('members', db.Model.metadata,
-	db.Column('committees_id', db.String(255), db.ForeignKey('committees.id')),
-	db.Column('users_id', db.String(255), db.ForeignKey('users.id'))
-)
+class Roles(Enum):
+	NormalMember = "NormalMember"
+	ActiveMember = "ActiveMember"
+	MinuteTaker = "MinuteTaker"
+
+class Members(db.Model):
+	__tablename__ = 'members'
+	committees_id = db.Column(db.String(255), db.ForeignKey('committees.id'), primary_key=True)
+	users_id = db.Column(db.String(255), db.ForeignKey('users.id'), primary_key=True)
+	role = db.Column(ChoiceType(Roles, impl=db.String()))
+	member = db.relationship('Users', backref= db.backref('committees', lazy='dynamic'))
+	committee = db.relationship('Committees', backref= db.backref('members', lazy='dynamic'))

--- a/app/members/test_members.py
+++ b/app/members/test_members.py
@@ -21,182 +21,258 @@ from sqlalchemy import create_engine
 
 class TestMembers(object):
 
-	@classmethod
-	def setup_class(self):
-		self.app = app.test_client()
+    @classmethod
+    def setup_class(self):
+        self.app = app.test_client()
 
-		app.config['TESTING'] = True
-		app.config['SQLALCHEMY_DATABASE_URI'] = config.SQLALCHEMY_TEST_DATABASE_URI
-		db = SQLAlchemy(app)
-		db.session.close()
-		db.drop_all()
-		db.create_all()
-		db.event.remove(Committees, "after_insert", new_committee)
-		self.socketio = socketio.test_client(app);
-		self.socketio.connect()
+        app.config['TESTING'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = config.SQLALCHEMY_TEST_DATABASE_URI
+        db = SQLAlchemy(app)
+        db.session.close()
+        db.drop_all()
+        db.create_all()
+        db.event.remove(Committees, "after_insert", new_committee)
+        self.socketio = socketio.test_client(app);
+        self.socketio.connect()
 
-	@classmethod
-	def setup_method(self, method):
-		db.drop_all()
-		db.create_all()
 
-		self.user_data = {
-			"user_id": "testuser",
-			"committee_id": "testcommittee",
-			"role": "NormalMember"
-		}
+    @classmethod
+    def setup_method(self, method):
+        db.drop_all()
+        db.create_all()
+
+        self.user_data = {
+            "user_id": "testuser",
+            "committee_id": "testcommittee",
+            "role": "NormalMember"
+        }
 
         # Create admin user for tests.
-		admin = Users(id = "adminuser")
-		admin.first_name = "Admin"
-		admin.last_name = "User"
-		admin.email = "adminuser@test.com"
-		admin.is_admin = True
-		db.session.add(admin)
-		#db.session.expunge(admin)
-		db.session.commit()
-		self.admin_token = admin.generate_auth()
-		self.admin_token = self.admin_token.decode('ascii')
+        admin = Users(id = "adminuser")
+        admin.first_name = "Admin"
+        admin.last_name = "User"
+        admin.email = "adminuser@test.com"
+        admin.is_admin = True
+        db.session.add(admin)
+        #db.session.expunge(admin)
+        db.session.commit()
+        self.admin_token = admin.generate_auth()
+        self.admin_token = self.admin_token.decode('ascii')
 
-		# Create normal user for tests.
-		self.user = Users(id = "testuser")
-		self.user.first_name = "Test1"
-		self.user.last_name = "User"
-		self.user.email = "testuser@test.com"
-		self.user.is_admin = False
-		db.session.add(self.user)
-		db.session.commit()
-		self.user_token = self.user.generate_auth()
-		self.user_token = self.user_token.decode('ascii')
+        # Create normal user for tests.
+        self.user = Users(id = "testuser")
+        self.user.first_name = "Test1"
+        self.user.last_name = "User"
+        self.user.email = "testuser@test.com"
+        self.user.is_admin = False
+        db.session.add(self.user)
+        db.session.commit()
+        self.user_token = self.user.generate_auth()
+        self.user_token = self.user_token.decode('ascii')
 
-		# Create normal user2 for tests.
-		self.user2 = Users(id = "test2user")
-		self.user2.first_name = "Test2"
-		self.user2.last_name = "User"
-		self.user2.email = "test2user@test.com"
-		self.user2.is_admin = False
-		db.session.add(self.user2)
-		db.session.commit()
-		self.user2_token = self.user2.generate_auth()
-		self.user2_token = self.user2_token.decode('ascii')
+        # Create normal user2 for tests.
+        self.user2 = Users(id = "test2user")
+        self.user2.first_name = "Test2"
+        self.user2.last_name = "User"
+        self.user2.email = "test2user@test.com"
+        self.user2.is_admin = False
+        db.session.add(self.user2)
+        db.session.commit()
+        self.user2_token = self.user2.generate_auth()
+        self.user2_token = self.user2_token.decode('ascii')
 
-		# Create a test committee.
-		self.committee = Committees(id = "testcommittee")
-		self.committee.title = "Test Committee"
-		self.committee.description = "Test Description"
-		self.committee.location = "Test Location"
-		self.committee.meeting_time = "1200"
-		self.committee.meeting_day = 2
-		self.committee.head = "adminuser"
+        # Create a test committee.
+        self.committee = Committees(id = "testcommittee")
+        self.committee.title = "Test Committee"
+        self.committee.description = "Test Description"
+        self.committee.location = "Test Location"
+        self.committee.meeting_time = "1200"
+        self.committee.meeting_day = 2
+        self.committee.head = "adminuser"
 
-		# Add user2 to committee.
-		role = Members(role= Roles.NormalMember)
-		role.member = self.user2
-		self.committee.members.append(role)
-		db.session.add(self.committee)
+        # Add user2 to committee.
+        role = Members(role= Roles.NormalMember)
+        role.member = self.user2
+        self.committee.members.append(role)
+        db.session.add(self.committee)
 
-		db.session.commit()
-
-	@classmethod
-	def teardown_class(self):
-		db.session.close()
-		db.drop_all()
-		db.event.listen(Committees, "after_insert", new_committee)
-		self.socketio.disconnect()
+        db.session.commit()
 
 
-	# Test get members of nonexistent committee.
-	def test_get_committee_members_nonexistent(self):
-		self.socketio.emit("get_members", "nonexistent")
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.ComDoesntExist
+    @classmethod
+    def teardown_class(self):
+        db.session.close()
+        db.drop_all()
+        db.event.listen(Committees, "after_insert", new_committee)
+        self.socketio.disconnect()
 
 
-	# Test get members of committee.
-	def test_get_committee_members(self):
-		self.socketio.emit("get_members", "testcommittee")
-		received = self.socketio.get_received()
-		commitee = received[0]["args"][0]
-		
-		result = {
-			'id': 'test2user',
-			'name': "Test2 User"
-		}
-
-		assert commitee["committee_id"] == "testcommittee"
-		assert (commitee["members"] == [result])
-
-	# Test add to committee when admin.
-	def test_add_to_committee(self):
-		self.user_data["token"] = self.admin_token
-		self.socketio.emit("add_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0]["members"][1]["id"] == self.user_data["user_id"]
-		assert received[1]["args"][0] == Response.AddSuccess
+    # Test get members of nonexistent committee.
+    def test_get_committee_members_nonexistent(self):
+        self.socketio.emit("get_members", "nonexistent")
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.ComDoesntExist
 
 
-	# Test add committee doesnt exist.
-	def test_add_non_existent(self):
-		self.user_data["token"] = self.admin_token
-		self.user_data["committee_id"] = "nonexistent"
-		self.socketio.emit("add_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.UserDoesntExist
+    # Test get members of committee.
+    def test_get_committee_members(self):
+        self.socketio.emit("get_members", "testcommittee")
+        received = self.socketio.get_received()
+        commitee = received[0]["args"][0]
+        
+        result = {
+            'id': 'test2user',
+            'name': "Test2 User",
+            'role': 'NormalMember'
+        }
+
+        assert commitee["committee_id"] == "testcommittee"
+        assert (commitee["members"] == [result])
 
 
-	# Test trying to remove not admin.
-	def test_remove_member_notadmim(self):
-		self.user_data["token"] = self.user_token
-		self.socketio.emit("remove_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.PermError
+    # Test add to committee when admin.
+    def test_add_to_committee(self):
+        self.user_data["token"] = self.admin_token
+        self.socketio.emit("add_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["members"][1]["id"] == self.user_data["user_id"]
+        assert received[1]["args"][0] == Response.AddSuccess
 
 
-	# Test remove member not admin
-	def test_remove_member_admin(self):
-		self.user_data["token"] = self.admin_token
-		self.user_data["user_id"] = self.user2.id
-		self.socketio.emit("remove_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		print (received)
-		assert received[0]["args"][0]["members"] == [] 
-		assert received[1]["args"][0] == Response.RemoveSuccess
+    # Test add to committee when admin and
+    # no role specified.
+    def test_add_to_committee_no_role(self):
+        self.user_data["token"] = self.admin_token
+        del self.user_data["role"]
+        self.socketio.emit("add_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["members"][1]["id"] == self.user_data["user_id"]
+        assert received[0]["args"][0]["members"][1]["role"] == Roles.NormalMember.value
+        assert received[1]["args"][0] == Response.AddSuccess
 
 
-	# Test remove nonexistent member.
-	def test_remove_member_nonexistent(self):
-		self.user_data["token"] = self.admin_token
-		self.user_data["user_id"] = "nonexistent"
-		self.socketio.emit("remove_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.UserDoesntExist
+    # Test add committee doesnt exist.
+    def test_add_non_existent(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["committee_id"] = "nonexistent"
+        self.socketio.emit("add_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserDoesntExist
 
 
-	# Test remove member nonexistent committee.
-	def test_remove_member_noncomm(self):
-		self.user_data["token"] = self.admin_token
-		self.user_data["committee_id"] = "nonexistent"
-		self.socketio.emit("remove_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.UserDoesntExist
+    # Test adding a member raises an Exception.
+    @patch('app.committees.models.Committees.members')
+    def test_add_exception(self, mock_obj):
+        mock_obj.append.side_effect = Exception("User couldn't be added.")
+        self.user_data["token"] = self.admin_token
+        self.socketio.emit("add_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.AddError
 
 
-	# Test adding a member raises an Exception.
-	@patch('app.committees.models.Committees.members')
-	def test_add_exception(self, mock_obj):
-		mock_obj.append.side_effect = Exception("User couldn't be added.")
-		self.user_data["token"] = self.admin_token
-		self.socketio.emit("add_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.AddError
+    # Test trying to remove not admin.
+    def test_remove_member_notadmin(self):
+        self.user_data["token"] = self.user_token
+        self.socketio.emit("remove_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
 
 
-	# Test removing a member raises an Exception.
-	@patch('app.members.controllers.db.session.delete')
-	def test_remove_exception(self, mock_obj):
-		mock_obj.side_effect = Exception("User couldn't be removed.")
-		self.user_data["token"] = self.admin_token
-		self.user_data["user_id"] = self.user2.id
-		self.socketio.emit("remove_member_committee", self.user_data)
-		received = self.socketio.get_received()
-		assert received[0]["args"][0] == Response.RemoveError
+    # Test remove member not admin
+    def test_remove_member_admin(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = self.user2.id
+        self.socketio.emit("remove_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        print (received)
+        assert received[0]["args"][0]["members"] == [] 
+        assert received[1]["args"][0] == Response.RemoveSuccess
+
+
+    # Test remove nonexistent member.
+    def test_remove_member_nonexistent(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = "nonexistent"
+        self.socketio.emit("remove_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserDoesntExist
+
+
+    # Test remove member nonexistent committee.
+    def test_remove_member_noncomm(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["committee_id"] = "nonexistent"
+        self.socketio.emit("remove_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserDoesntExist
+
+
+    # Test removing a member raises an Exception.
+    @patch('app.members.controllers.db.session.delete')
+    def test_remove_exception(self, mock_obj):
+        mock_obj.side_effect = Exception("User couldn't be removed.")
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = self.user2.id
+        self.socketio.emit("remove_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.RemoveError
+
+
+    # Test trying to remove not admin.
+    def test_edit_member_notadmin(self):
+        self.user_data["token"] = self.user_token
+        self.user_data["role"] = Roles.ActiveMember.value
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
+
+
+    # Test remove member not admin
+    def test_edit_member_admin(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = self.user2.id
+        self.user_data["role"] = Roles.ActiveMember.value
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.EditSuccess
+
+
+    # Test remove nonexistent member.
+    def test_edit_member_nonexistent(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = "nonexistent"
+        self.user_data["role"] = Roles.ActiveMember.value
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserDoesntExist
+
+
+    # Test remove member nonexistent committee.
+    def test_edit_member_noncomm(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["committee_id"] = "nonexistent"
+        self.user_data["role"] = Roles.ActiveMember.value
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserDoesntExist
+
+
+    # Test remove member nonexistent role.
+    def test_edit_member_nonrole(self):
+        self.user_data["token"] = self.admin_token
+        self.user_data["role"] = "nonexistent"
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.RoleDoesntExist
+
+
+    # Test editing a member raises an Exception.
+    @patch('app.committees.models.Committees.members')
+    def test_edit_exception(self, mock_obj):
+        mock_obj.filter_by.side_effect = Exception("User couldn't be edited.")
+        self.user_data["token"] = self.admin_token
+        self.user_data["user_id"] = self.user2.id
+        self.user_data["role"] = Roles.ActiveMember.value
+        self.socketio.emit("edit_role_member_committee", self.user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.EditError

--- a/app/users/controllers.py
+++ b/app/users/controllers.py
@@ -149,7 +149,6 @@ def login_ldap(credentials):
 def edit_roles(user, user_data):
     if not user.is_super:
         emit('auth', Response.PermError)
-        print(user.is_super)
         return;
 
     edit_user = Users.query.filter_by(id = user_data["username"]).first()

--- a/app/users/controllers.py
+++ b/app/users/controllers.py
@@ -64,6 +64,7 @@ def verify(user, user_data):
 
     emit('verify_auth', {
         'admin': user.is_admin,
+        'super': user.is_super,
         'username': user.id
     })
 
@@ -104,6 +105,7 @@ def login_ldap(credentials):
             emit('auth', {
                 'token': token.decode('ascii'),
                 'admin': admin,
+                'super': user.is_super,
                 'username': username
             })
 

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -6,7 +6,6 @@ created on: 08/31/17
 """
 from app import app, db, login_manager
 from enum import Enum
-from app.members.models import members_table
 from flask_login import UserMixin
 from itsdangerous import (TimedJSONWebSignatureSerializer
                           as Serializer, BadSignature, SignatureExpired)
@@ -19,7 +18,7 @@ class Users(UserMixin, db.Model):
 	email = db.Column(db.String(255))
 	is_admin = db.Column(db.Boolean)
 	is_super = db.Column(db.Boolean)
-	committees = db.relationship('Committees', secondary= members_table, back_populates= 'members')
+	#committees = db.relationship('Members', back_populates= 'member')
 
 
 	@login_manager.user_loader

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -5,6 +5,7 @@ created by: Omar De La Hoz (oed7416@rit.edu)
 created on: 08/31/17
 """
 from app import app, db, login_manager
+from enum import Enum
 from app.members.models import members_table
 from flask_login import UserMixin
 from itsdangerous import (TimedJSONWebSignatureSerializer
@@ -17,6 +18,7 @@ class Users(UserMixin, db.Model):
 	last_name = db.Column(db.String(255))
 	email = db.Column(db.String(255))
 	is_admin = db.Column(db.Boolean)
+	is_super = db.Column(db.Boolean)
 	committees = db.relationship('Committees', secondary= members_table, back_populates= 'members')
 
 
@@ -42,3 +44,11 @@ class Users(UserMixin, db.Model):
 			return None
 		user = Users.query.get(data['id'])
 		return user
+
+##
+## @brief      Class for User Roles.
+##
+class Roles(Enum):
+	NormalUser = 'NormalUser'
+	AdminUser = 'AdminUser'
+	ManagerUser = 'ManagerUser'

--- a/app/users/test_user.py
+++ b/app/users/test_user.py
@@ -164,10 +164,16 @@ class TestUser(object):
             assert res.status == "302 FOUND"
 
     def test_get_all_users(self):
-        return_data = [{
-            "username": self.user.id,
-            "name": self.user.first_name + " " + self.user.last_name
-        }]
+        return_data = [
+            {
+                "username": self.user.id,
+                "name": self.user.first_name + " " + self.user.last_name,
+            },
+            {
+                "username": self.admin_user.id,
+                "name": self.admin_user.first_name + " " + self.admin_user.last_name
+            }
+        ]
 
         self.socketio.emit("get_all_users")
         received = self.socketio.get_received()

--- a/app/users/test_user.py
+++ b/app/users/test_user.py
@@ -11,7 +11,7 @@ import config
 from mock import patch, MagicMock
 from pytest_mock import mocker
 from app import app, db, socketio
-from app.users.models import Users
+from app.users.models import Users, Roles
 from app.users.controllers import login_from_acs
 from flask_socketio import SocketIOTestClient
 from flask_sqlalchemy import SQLAlchemy
@@ -51,6 +51,19 @@ class TestUser(object):
         db.session.commit() 
         self.user_token = self.user.generate_auth() 
         self.user_token = self.user_token.decode('ascii') 
+
+        # Create admin user for tests.
+        self.admin_user = Users(id = "adminuser") 
+        self.admin_user.first_name = "Admin" 
+        self.admin_user.last_name = "User" 
+        self.admin_user.email = "adminuser@test.com" 
+        self.admin_user.is_admin = True 
+        self.admin_user.is_super = True
+        db.session.add(self.admin_user) 
+        db.session.commit() 
+        self.admin_user_token = self.admin_user.generate_auth() 
+        self.admin_user_token = self.admin_user_token.decode('ascii')
+
 
     @classmethod
     def teardown_class(self):
@@ -159,3 +172,105 @@ class TestUser(object):
         self.socketio.emit("get_all_users")
         received = self.socketio.get_received()
         assert received[0]["args"][0] == return_data
+
+    # Test edit roles without being an admin.
+    def test_edit_roles_no_permissions(self):
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.user_token, 
+                "username": "testuser",
+                "role": Roles.AdminUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
+
+    # Test edit role of non-existing user.
+    def test_edit_roles_user_not_found(self):
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.admin_user_token, 
+                "username": "non-existing",
+                "role": Roles.AdminUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.UserNotFound
+
+    # Test edit non existing role.
+    def test_edit_role_not_found(self):
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.admin_user_token, 
+                "username": "testuser",
+                "role": "NonExistingRole"
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.RoleNotFound
+
+    # Test set roles to manager user.
+    def test_set_to_manager(self):
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.admin_user_token, 
+                "username": "testuser",
+                "role": Roles.ManagerUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == {"success": "Role set to ManagerUser."}
+
+    # Test manager shouldnt edit roles.
+    def test_manager_cant_edit_role(self):
+        self.socketio.emit("edit_roles",
+            {
+                "token": self.user_token, 
+                "username": "adminuser",
+                "role": Roles.ManagerUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
+
+    # Test set manager to admin user.
+    def test_set_to_admin(self):
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.admin_user_token, 
+                "username": "testuser",
+                "role": Roles.AdminUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == {"success": "Role set to AdminUser."}
+
+    # Test set admin to normal user.
+    def test_set_to_normal(self):
+
+        # Make testuser an admin.
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.admin_user_token, 
+                "username": "testuser",
+                "role": Roles.AdminUser.value
+            }
+        )
+
+        # Make admin a normal user.
+        self.socketio.emit("edit_roles", 
+            {
+                "token": self.user_token, 
+                "username": "adminuser",
+                "role": Roles.NormalUser.value
+            }
+        )
+
+        received = self.socketio.get_received()
+        assert received[1]["args"][0] == {"success": "Role set to NormalUser."}

--- a/app/users/users_response.py
+++ b/app/users/users_response.py
@@ -6,4 +6,8 @@ created on: 10/12/18
 """
 
 class Response():
-	AuthError = {'error': 'Authentication error.'}
+    AuthError = {'error': 'Authentication error.'}
+    PermError = {'error': 'Insufficient permissions to perform this action.'}
+    DBError = {'error': 'Could not complete action.'}
+    UserNotFound = {'error': 'User not found.'}
+    RoleNotFound = {'error': 'Role not found.'}


### PR DESCRIPTION
How changes affect each model:

**Members**
- Memberships have a role, now they can be chosen from:
  - NormalMember (Can view public and private committee data)
  - ActiveMember (Can create private charges)
  - MinuteTaker (Can create private meeting minutes **in development**)
- Get members now returns an array of members containing:
  - id (Id of the member)
  - name (First and last name concatenated)
  - role (Sting representation of user role)

**Charges**
- Charge getters were modified:
  - **get_all_charges** only gets public charges.
  - **get_charges** only gets public charges of a committee if not a member.
  - **get_charge** now includes if a charge is private or not.
- Charge creation
  - Active member can create private charges
  - Committee head can create public and private charges
  - Permission error if an active member attempts to create a public charge.
- Charge edition
  - Only comittee head can change charge to public

**Users**
- **verify_auth**  and **auth**  now return "admin", "super" and "username" fields.
  - **auth** also returns token (LDAP authentication).
- The default user role is NormalMember
- Users have a role, now they can be chosen from:
  - NormalUser (no admin privileges)
  - ManagerUser (Has all permissions except the ability to promote users to manager or admin)
    - A manager role is a user with only **admin** set to true.
  - AdminUser (Has all permissions and can add admins/managers)
    - An admin rule is a user with both **admin** and **super** set to true.
- Can now modify user roles through **edit_roles**
  - Only AdminUser can edit roles.





