### PR TITLE
Move charge between committees.

### DIFF
--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -257,10 +257,15 @@ def edit_charge(user, user_data):
         not user.is_admin and user.id != committee.head):
         emit("edit_charge", Response.PermError)
         return
+    
+    # Only admins can move charges to a different committee.
+    if ('committee' in user_data and user.is_admin == False):
+        emit("edit_charge", Response.PermError)
+        return
 
     for key in user_data:
         if (key == "description" or key == "title" or key == "priority" or
-            key == "status" or key == "paw_links" or key == "private"):
+            key == "status" or key == "paw_links" or key == "private" or key == "committee"):
             setattr(charge, key, user_data[key])
 
     try:

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -103,11 +103,22 @@ class TestCharges(object):
         committee.head = "testuser"
         self.committee = committee
 
+        # Create a test committee.
+        committee2 = Committees(id = "testcommittee2")
+        committee2.title = "Test Committee2"
+        committee2.description = "Test Description"
+        committee2.location = "Test Location"
+        committee2.meeting_time = "1300"
+        committee2.meeting_day =  2
+        committee2.head = "testuser"
+        self.committee2 = committee2
+
         # Add user3 to committee.
         role = Members(role= Roles.ActiveMember)
         role.member = self.test_user3
         self.committee.members.append(role)
         db.session.add(self.committee)
+        db.session.add(self.committee2)
         db.session.commit()
 
         self.charge_dict={
@@ -414,6 +425,29 @@ class TestCharges(object):
         }
         self.charge_dict["title"] = user_data["title"]
 
+        self.socketio.emit('edit_charge', user_data)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.PermError
+    
+    def test_edit_charge_change_committee(self):
+        user_data = {
+            "token": self.admin_token,
+            "charge": 10,
+            "committee": self.committee2.id
+        }
+
+        self.charge_dict["committee"] = user_data["committee"]
+
+        self.socketio.emit('edit_charge', user_data)
+        received = self.socketio.get_received()
+        assert received[1]["args"][0] == self.charge_dict
+
+    def test_edit_charge_change_committee_no_perm(self):
+        user_data = {
+            "token": self.user_token,
+            "charge": 10,
+            "committee": self.committee.id
+        }
         self.socketio.emit('edit_charge', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.PermError

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ huey==1.10.2
 idna==2.6
 isodate==0.6.0
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 jsonify==0.5
 lxml==4.2.5
 MarkupSafe==1.0
@@ -48,9 +48,9 @@ requests==2.20.0
 sentry-sdk==0.4.0
 simpledb==0.4.2
 six==1.11.0
-SQLAlchemy==1.2.7
+SQLAlchemy==1.3.3
 SQLAlchemy-Utils==0.33.3
 typing==3.6.6
-urllib3==1.22
+urllib3==1.24.1
 Werkzeug==0.14.1
 xmlsec==1.3.3


### PR DESCRIPTION
In this PR:
- The edit_charge was modified to accept editing the committee of a charge, only managers and admins can move a charge from a committee to another.
- Updated unit tests for this.
- Updated vulnerabilities found by Git.
