### PR TITLE
TT-102: Remove Create Private Charges from Active Member Permissions

### DIFF
--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -165,8 +165,7 @@ def create_charge(user, user_data):
     # Get the members role.
     membership = committee.members.filter_by(member= user).first()
 
-    if (user.id != committee.head and user.is_admin == False and
-        (membership is None or membership.role != Roles.ActiveMember)):
+    if (user.id != committee.head and user.is_admin == False):
         emit("create_charge", Response.PermError)
         return;
 

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -188,7 +188,7 @@ class TestCharges(object):
 
         self.socketio.emit('create_charge', user_data)
         received = self.socketio.get_received()
-        assert received[0]["args"][0] == Response.AddSuccess
+        assert received[0]["args"][0] == Response.PermError
 
     def test_create_charge_no_permission(self):
         user_data = {


### PR DESCRIPTION
**In this PR:**

- Updated controllers so only committee heads and admins can create charges.
- Updated unit tests.