### PR TITLE
TT-139 - Re-Structure Access Controls

### DIFF
--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -234,7 +234,7 @@ def edit_charge(user, user_data):
     committee = Committees.query.filter_by(id = charge.committee).first()
     membership = committee.members.filter_by(member= user).first()
 
-    if user.id != committee.head and not user.is_admin:
+    if (membership is None or membership.role != Roles.CommitteeHead) and not user.is_admin:
         emit("edit_charge", Response.PermError)
         return
     

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -158,9 +158,6 @@ def create_charge(user, user_data):
         emit("create_charge", Response.UsrChargeDontExist)
         return
 
-    # Get the members role.
-    membership = committee.members.filter_by(member= user).first()
-
     if (user.id != committee.head and not user.is_admin):
         emit("create_charge", Response.PermError)
         return

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -156,31 +156,25 @@ def create_charge(user, user_data):
 
     if committee is None or user is None:
         emit("create_charge", Response.UsrChargeDontExist)
-        return;
+        return
 
     # Get the members role.
     membership = committee.members.filter_by(member= user).first()
 
-    if (user.id != committee.head and user.is_admin == False):
+    if (user.id != committee.head and not user.is_admin):
         emit("create_charge", Response.PermError)
-        return;
+        return
 
     if "title" not in user_data:
         emit ("create_charge", Response.InvalidTitle)
-        return;
+        return
 
     if ("priority" not in user_data or
         type(user_data["priority"]) != int or 
         user_data["priority"] < 0 or
         user_data["priority"] > 2):
         emit ("create_charge", Response.InvalidPriority)
-        return;
-
-    # Only admins and committee heads can make charges public.
-    if ('private' in user_data and not user_data['private'] and
-        not user.is_admin and user.id != committee.head):
-        emit("create_charge", Response.PermError)
-        return;
+        return
 
     charge = Charges(title = user_data["title"])
     charge.author = user.id

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -54,30 +54,31 @@ def get_all_charges(broadcast = False):
 @socketio.on('get_charges')
 @ensure_dict
 @get_user
-def get_charges(user, user_data, broadcast = False):
+def get_charges(user, user_data, broadcast = False):   
+    charge_ser = []
     committee_id = user_data.get("committee_id", "")
     committee = Committees.query.filter_by(id = committee_id).first()
-    membership = committee.members.filter_by(member= user).first()
 
-    if (user is not None and user.is_admin) or membership is not None:
-        charges = Charges.query.filter_by(committee= committee_id).all()
-    else:
-        charges = Charges.query.filter_by(committee= committee_id, private = False).all()
-    
-    charge_ser = []
+    if committee is not None:
+        membership = committee.members.filter_by(member= user).first()
+        if (user is not None and user.is_admin) or membership is not None:
+            charges = Charges.query.filter_by(committee= committee_id).all()
+        else:
+            charges = Charges.query.filter_by(committee= committee_id, private = False).all()
 
-    for charge in charges:
-        charge_ser.append({
-            "id": charge.id,
-            "title": charge.title,
-            "description": charge.description,
-            "committee": charge.committee,
-            "priority": charge.priority,
-            "status": charge.status,
-            "paw_links": charge.paw_links,
-            "private": charge.private,
-            "created_at": charge.created_at.isoformat()
-        })
+        for charge in charges:
+            charge_ser.append({
+                "id": charge.id,
+                "title": charge.title,
+                "description": charge.description,
+                "committee": charge.committee,
+                "priority": charge.priority,
+                "status": charge.status,
+                "paw_links": charge.paw_links,
+                "private": charge.private,
+                "created_at": charge.created_at.isoformat()
+            })
+
     emit("get_charges", charge_ser, broadcast = broadcast)
 
 
@@ -106,7 +107,7 @@ def get_charge(user, user_data, broadcast = False):
     membership = committee.members.filter_by(member= user).first()
 
     if charge.private:
-        if user is None or not user.is_admin or membership is None:
+        if user is None or (not user.is_admin and membership is None):
             emit('get_charge', Response.PermError)
             return
 

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -20,18 +20,15 @@ from app.users.models import Users
 ##
 ## @param      broadcast  The broadcast
 ##
-## @return     All charges.
+## @return     All public charges.
 ##
 @socketio.on('get_all_charges')
 def get_all_charges(broadcast = False):
 
-    charges = Charges.query.filter_by().all()
+    charges = Charges.query.filter_by(private = False).all()
     charge_ser = []
 
     for charge in charges:
-        if charge.private:
-            continue;
-
         charge_ser.append({
             "id": charge.id,
             "title": charge.title,

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -59,10 +59,10 @@ def get_charges(user, user_data, broadcast = False):
     committee = Committees.query.filter_by(id = committee_id).first()
     membership = committee.members.filter_by(member= user).first()
 
-    if membership is None:
-        charges = Charges.query.filter_by(committee= committee_id, private = False).all()
-    else:
+    if user.is_admin or membership is not None:
         charges = Charges.query.filter_by(committee= committee_id).all()
+    else:
+        charges = Charges.query.filter_by(committee= committee_id, private = False).all()
     
     charge_ser = []
 

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -238,8 +238,8 @@ def edit_charge(user, user_data):
         return
     
     # Only admins can move charges to a different committee.
-    committee = user_data.get("committee", committee.id)
-    if (committee != committee.id and not user.is_admin):
+    committee_id = user_data.get("committee", committee.id)
+    if (committee_id != committee.id and not user.is_admin):
         emit("edit_charge", Response.PermError)
         return
 

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -55,20 +55,18 @@ def get_all_charges(broadcast = False):
 @ensure_dict
 @get_user
 def get_charges(user, user_data, broadcast = False):
-    charges = Charges.query.filter_by(committee= user_data.get("committee_id", "")).all()
-    charge_ser = []
-
-    if len(charges) == 0:
-        emit("get_charges", charge_ser, broadcast = broadcast)
-        return;
-
-    committee = Committees.query.filter_by(id = user_data.get("committee_id", "")).first()
+    committee_id = user_data.get("committee_id", "")
+    committee = Committees.query.filter_by(id = committee_id).first()
     membership = committee.members.filter_by(member= user).first()
 
-    for charge in charges:
-        if charge.private and membership is None:
-            continue;
+    if membership is None:
+        charges = Charges.query.filter_by(committee= committee_id, private = False).all()
+    else:
+        charges = Charges.query.filter_by(committee= committee_id).all()
+    
+    charge_ser = []
 
+    for charge in charges:
         charge_ser.append({
             "id": charge.id,
             "title": charge.title,
@@ -79,7 +77,7 @@ def get_charges(user, user_data, broadcast = False):
             "paw_links": charge.paw_links,
             "private": charge.private,
             "created_at": charge.created_at.isoformat()
-        });
+        })
     emit("get_charges", charge_ser, broadcast = broadcast)
 
 

--- a/app/charges/controllers.py
+++ b/app/charges/controllers.py
@@ -233,19 +233,13 @@ def edit_charge(user, user_data):
     committee = Committees.query.filter_by(id = charge.committee).first()
     membership = committee.members.filter_by(member= user).first()
 
-    if (user.id != committee.head and user.is_admin == False and
-        (membership is None or membership.role != Roles.ActiveMember)):
-        emit("edit_charge", Response.PermError)
-        return
-
-    # Only admins and committee heads can make charges public.
-    if ('private' in user_data and not user_data['private'] and
-        not user.is_admin and user.id != committee.head):
+    if user.id != committee.head and not user.is_admin:
         emit("edit_charge", Response.PermError)
         return
     
     # Only admins can move charges to a different committee.
-    if ('committee' in user_data and user.is_admin == False):
+    committee = user_data.get("committee", committee.id)
+    if (committee != committee.id and not user.is_admin):
         emit("edit_charge", Response.PermError)
         return
 

--- a/app/charges/test_charges.py
+++ b/app/charges/test_charges.py
@@ -464,4 +464,4 @@ class TestCharges(object):
 
         self.socketio.emit('edit_charge', user_data)
         received = self.socketio.get_received()
-        assert received[0]["args"][0] == Response.EditError
+        assert received[0]["args"][0] == Response.PermError

--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -44,7 +44,7 @@ def get_minute(user, user_data):
 
     membership = committee.members.filter_by(member = user).first()
 
-    if minute.private and (membership is None and not user.is_admin and committee.head != user.id):
+    if minute.private and (membership is None and not user.is_admin):
         emit('get_minute', Response.PermError)
         return
     
@@ -88,7 +88,7 @@ def get_minutes(user, user_data):
     membership = committee.members.filter_by(member= user).first()
     minutes = None
 
-    if (membership is None and not user.is_admin and committee.head != user.id):
+    if (membership is None and not user.is_admin):
         minutes = committee.minutes.filter_by(private= False).all()
     else:
         minutes = committee.minutes.all()

--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -239,15 +239,14 @@ def edit_minute(user, user_data):
 
     membership = committee.members.filter_by(member= user).first()
 
-    if (user.id != committee.head and user.is_admin == False and
-        (membership is None or membership.role != Roles.MinuteTaker)):
+    if membership is None and not user.is_admin:
         emit('edit_minute', Response.PermError)
         return
     
-    if (user.id != committee.head and 
-        "private" in user_data and not user_data["private"]):
-        emit('create_minute', Response.PermError)
-        return
+    if "private" in user_data and not user_data["private"]:
+        if user.id != committee.head and not user.is_admin:
+            emit('create_minute', Response.PermError)
+            return
     
     deleted = []
     new = []

--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -150,7 +150,8 @@ def create_minute(user, user_data):
         emit('create_minute', Response.PermError)
         return
     
-    if not user_data["private"] and (user.id != committee.head or not user.is_admin):
+    is_public = not user_data.get("private", False)
+    if is_public and (user.id != committee.head or not user.is_admin):
         emit('create_minute', Response.PermError)
         return
     
@@ -243,7 +244,7 @@ def edit_minute(user, user_data):
         emit('edit_minute', Response.PermError)
         return
     
-    if "private" in user_data and not user_data["private"]:
+    if not user_data.get("private", False):
         if user.id != committee.head and not user.is_admin:
             emit('create_minute', Response.PermError)
             return

--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -146,7 +146,7 @@ def create_minute(user, user_data):
     # Get the members role.
     membership = committee.members.filter_by(member= user).first()
 
-    if membership is None:
+    if membership is None and not user.is_admin:
         emit('create_minute', Response.PermError)
         return
     

--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -146,12 +146,11 @@ def create_minute(user, user_data):
     # Get the members role.
     membership = committee.members.filter_by(member= user).first()
 
-    if (user.id != committee.head and user.is_admin == False and
-        (membership is None or membership.role != Roles.MinuteTaker)):
+    if membership is None:
         emit('create_minute', Response.PermError)
         return
     
-    if user.id != committee.head and not user_data["private"]:
+    if not user_data["private"] and (user.id != committee.head or not user.is_admin):
         emit('create_minute', Response.PermError)
         return
     

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -394,7 +394,8 @@ class TestMinutes(object):
     def test_edit_minute_minute_taker(self):
         user_data = {
             "token": self.minute_taker_token,
-            "minute_id": self.minute.id
+            "minute_id": self.minute.id,
+            "private": True
         }
         self.socketio.emit("edit_minute", user_data)
         received = self.socketio.get_received()

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -289,7 +289,7 @@ class TestMinutes(object):
         self.socketio.emit("create_minute", self.user_data)
         received = self.socketio.get_received()
         response = received[0]["args"][0]
-        assert response == Response.PermError
+        assert response == Response.AddMinuteSuccess
     
     def test_create_minute_minute_taker_public(self):
         self.user_data["token"] = self.minute_taker_token


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-139

**Issue summary**
There are cases where the privileges associated with certain roles aren't active in practice. For example an admin doesn't have proper access of charges and minutes.

**Big-picture overview of solution and motivation**
My approach to the issue was to change as little as needed. The changes focus mainly on the sections of code where it's possible to return a permission error to the client. In these cases I followed the diagram on the ticket to try the keep the conditionals as concise as possible.

In other places I moved logic into the database call. There were some instances in the code where we filter charges or minutes depending on the privileges of the user. Rather than retrieving all entities then filtering them on the python side, I moved this logic into the database call which will make it faster.

**Testing**
As of the opening of this PR no additional tests have been created. This is under the assumption that the preexisting tests will capture the desired behavior despite the changes to logic.