### PR TITLE
TT-204 - Removed all mention of is_super

### DIFF
--- a/app/users/controllers.py
+++ b/app/users/controllers.py
@@ -64,7 +64,6 @@ def verify(user, user_data):
 
     emit('verify_auth', {
         'admin': user.is_admin,
-        'super': user.is_super,
         'username': user.id
     })
 
@@ -105,7 +104,6 @@ def login_ldap(credentials):
             emit('auth', {
                 'token': token.decode('ascii'),
                 'admin': admin,
-                'super': user.is_super,
                 'username': username
             })
 
@@ -147,7 +145,7 @@ def login_ldap(credentials):
 @ensure_dict
 @get_user
 def edit_roles(user, user_data):
-    if not user.is_super:
+    if not user.is_admin:
         emit('auth', Response.PermError)
         return;
 
@@ -165,13 +163,10 @@ def edit_roles(user, user_data):
 
     if role == Roles.AdminUser:
         edit_user.is_admin = True
-        edit_user.is_super = True
     elif role == Roles.ManagerUser:
         edit_user.is_admin = True
-        edit_user.is_super = False
     else:
         edit_user.is_admin = False
-        edit_user.is_super = False
 
     try:
         db.session.commit()

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -17,7 +17,6 @@ class Users(UserMixin, db.Model):
 	last_name = db.Column(db.String(255))
 	email = db.Column(db.String(255))
 	is_admin = db.Column(db.Boolean)
-	is_super = db.Column(db.Boolean)
 	#committees = db.relationship('Members', back_populates= 'member')
 
 

--- a/app/users/test_user.py
+++ b/app/users/test_user.py
@@ -58,7 +58,6 @@ class TestUser(object):
         self.admin_user.last_name = "User" 
         self.admin_user.email = "adminuser@test.com" 
         self.admin_user.is_admin = True 
-        self.admin_user.is_super = True
         db.session.add(self.admin_user) 
         db.session.commit() 
         self.admin_user_token = self.admin_user.generate_auth() 


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-204

There are two fields in the user table that have the same use, `is_admin` and `is_super`. `is_super` is only used in one place in the backend, and is not used at all in the frontend. 

I replaced the one place that `is_super` is used with `is_admin`, and deleted it from the User model for the database.

There is no new tests written since this ticket was just pruning an unused variable.