### PR TITLE
TT-203 - When not logged in Auth bugs occur

### DIFF
--- a/app/minutes/controllers.py
+++ b/app/minutes/controllers.py
@@ -31,10 +31,6 @@ from app.users.models import Users
 @get_user
 def get_minute(user, user_data):
     minute = Minutes.query.filter_by(id= user_data.get("minute_id", -1)).first()
-    
-    if user is None:
-        emit('get_minute', Response.UserDoesntExist)
-        return
 
     if minute is None:
         emit('get_minute', Response.MinuteDoesntExist)
@@ -44,9 +40,10 @@ def get_minute(user, user_data):
 
     membership = committee.members.filter_by(member = user).first()
 
-    if minute.private and (membership is None and not user.is_admin):
-        emit('get_minute', Response.PermError)
-        return
+    if minute.private:
+        if user is None or (membership is None and not user.is_admin):
+            emit('get_minute', Response.PermError)
+            return
     
     minute_data = {
         'id': minute.id,
@@ -75,10 +72,6 @@ def get_minute(user, user_data):
 @get_user
 def get_minutes(user, user_data):
     committee = Committees.query.filter_by(id = user_data.get("committee_id","")).first()
-
-    if user is None:
-        emit('get_minutes', Response.UserDoesntExist)
-        return
     
     if committee is None:
         emit('get_minutes', Response.CommitteeDoesntExist)
@@ -88,7 +81,7 @@ def get_minutes(user, user_data):
     membership = committee.members.filter_by(member= user).first()
     minutes = None
 
-    if (membership is None and not user.is_admin):
+    if user is None or (membership is None and not user.is_admin):
         minutes = committee.minutes.filter_by(private= False).all()
     else:
         minutes = committee.minutes.all()

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -173,7 +173,7 @@ class TestMinutes(object):
             'charges': [{'id': 10, 'title': "Test Charge"}]
         }]
 
-        assert response == []
+        assert response == result
     
     def test_get_minutes_no_committee(self):
         self.user_data["committee_id"] = ""

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -158,7 +158,7 @@ class TestMinutes(object):
 
         received = self.socketio.get_received()
         response = received[0]["args"][0]
-        assert response == []]
+        assert response == []
     
     def test_get_minutes_no_committee(self):
         self.user_data["committee_id"] = ""

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -188,7 +188,18 @@ class TestMinutes(object):
         self.socketio.emit("get_minutes", self.user_data)
         received = self.socketio.get_received()
         response = received[0]["args"][0]
-        assert response == []
+
+        result = [{
+            'id': 2,
+            'title': 'Public Test Minute',
+            'body': 'PublicTestBody',
+            'date': 282827,
+            'private': False,
+            'committee_id': 'testcommittee',
+            'charges': [{'id': 10, 'title': "Test Charge"}]
+        }]
+
+        assert response == result
     
     def test_get_minutes_success(self):
         self.socketio.emit("get_minutes", self.user_data)
@@ -201,6 +212,15 @@ class TestMinutes(object):
             'body': 'TestBody',
             'date': 282827,
             'private': True,
+            'committee_id': 'testcommittee',
+            'charges': [{'id': 10, 'title': "Test Charge"}]
+        },
+        {
+            'id': 2,
+            'title': 'Public Test Minute',
+            'body': 'PublicTestBody',
+            'date': 282827,
+            'private': False,
             'committee_id': 'testcommittee',
             'charges': [{'id': 10, 'title': "Test Charge"}]
         }]

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -158,7 +158,7 @@ class TestMinutes(object):
 
         received = self.socketio.get_received()
         response = received[0]["args"][0]
-        assert response == Response.UserDoesntExist
+        assert response == []]
     
     def test_get_minutes_no_committee(self):
         self.user_data["committee_id"] = ""
@@ -222,7 +222,7 @@ class TestMinutes(object):
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.MinuteDoesntExist
 
-    def test_get_minute_no_user(self):
+    def test_get_private_minute_no_user(self):
         user_data = {
             "token": '',
             "minute_id": self.minute.id
@@ -230,7 +230,7 @@ class TestMinutes(object):
 
         self.socketio.emit('get_minute', user_data)
         received = self.socketio.get_received()
-        assert received[0]["args"][0] == Response.UserDoesntExist
+        assert received[0]["args"][0] == Response.PermError
 
     def test_get_minute_no_minute(self):
         self.socketio.emit('get_minute', self.user_data)

--- a/app/minutes/test_minutes.py
+++ b/app/minutes/test_minutes.py
@@ -143,6 +143,10 @@ class TestMinutes(object):
         self.minute.charges.append(self.charge)
         self.committee.minutes.append(self.minute)
 
+        self.public_minute = Minutes(title="Public Test Minute", body="PublicTestBody", date= 282827, private= False)
+        self.public_minute.charges.append(self.charge)
+        self.committee.minutes.append(self.public_minute)
+
         db.session.commit()
     
     @classmethod
@@ -158,6 +162,17 @@ class TestMinutes(object):
 
         received = self.socketio.get_received()
         response = received[0]["args"][0]
+
+        result = [{
+            'id': 2,
+            'title': 'Public Test Minute',
+            'body': 'PublicTestBody',
+            'date': 282827,
+            'private': False,
+            'committee_id': 'testcommittee',
+            'charges': [{'id': 10, 'title': "Test Charge"}]
+        }]
+
         assert response == []
     
     def test_get_minutes_no_committee(self):


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-203

When a user navigates to a committee, charge, or minutes page while they are not logged in, the page doesn't get populated with data. This is because the backend is set up in such a way that if you are not logged in, it returns an error. This error is not handled by the frontend so the page just looks broken.

To fix this I made changes to both the frontend and the backend. For the backend the logic was already in place for the `get_charge` function to properly allow users who aren't logged in to see public charges. This means I only had to change the logic for `get_minute` and `get_minutes` to allow unauthenticated users to view public minutes.

There aren't any unit tests written right now, but I will write some after I see how the code coverage is affected. The logic has changed quite a bit from when the tests were originally written, and some may need to be refactored or new tests may need to be written.