### PR TITLE
TT-209 - Check for user in get_notifications

### DIFF
--- a/app/notifications/controllers.py
+++ b/app/notifications/controllers.py
@@ -31,8 +31,11 @@ notifications_table = Notifications.__table__.insert()
 @ensure_dict
 @get_user
 def get_notifications(user, user_data):
-    notifications = Notifications.query.filter_by(user = user.id).all()
-    noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "viewed": c.viewed, "message": c.message, "redirect": c.redirect} for c in notifications]
+    noti_ser = []
+
+    if user is not None:
+        notifications = Notifications.query.filter_by(user = user.id).all()
+        noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "viewed": c.viewed, "message": c.message, "redirect": c.redirect} for c in notifications]
     emit('get_notifications', noti_ser)
 
 

--- a/app/notifications/test_notifications.py
+++ b/app/notifications/test_notifications.py
@@ -223,6 +223,10 @@ class TestNotifications(object):
         assert received[0]["args"][0][0] == expected
 
     def test_no_user_get_notifications(self):
-        self.socketio.emit('get_notifications')
+        user_data = {
+            'token': None
+        }
+
+        self.socketio.emit('get_notifications', user_data)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == []

--- a/app/notifications/test_notifications.py
+++ b/app/notifications/test_notifications.py
@@ -221,3 +221,8 @@ class TestNotifications(object):
             'redirect': '/charge/10'
         }
         assert received[0]["args"][0][0] == expected
+
+    def test_no_user_get_notifications(self):
+        self.socketio.emit('get_notifications')
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == []


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-218

The `get_notifications` endpoint can get called even if the user is not logged in which causes an error. This pull request checks if user is None before attempting to access their id.

As of the opening of this PR there isn't any additional tests but it makes sense to add one to make sure that an empty array is returned.