### PR TITLE
TT-219 - Removed print statement

### DIFF
--- a/app/notifications/controllers.py
+++ b/app/notifications/controllers.py
@@ -95,7 +95,6 @@ def new_note(mapper, connection, new_note):
 ##
 @listens_for(Actions, 'after_insert')
 def new_action(mapper, connection, new_action):
-    print(new_action.charge)
     connection.execute(notifications_table,
         user = new_action.assigned_to,
         type = NotificationType.AssignedToAction,


### PR DESCRIPTION
I noticed a print statement in one of the notifications controllers that seems like it was left over from debugging. This PR just removes it.