### PR TITLE
TT-220 - Delete notifications after viewing them

### DIFF
--- a/app/notifications/controllers.py
+++ b/app/notifications/controllers.py
@@ -35,7 +35,7 @@ def get_notifications(user, user_data):
 
     if user is not None:
         notifications = Notifications.query.filter_by(user = user.id).all()
-        noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "viewed": c.viewed, "message": c.message, "redirect": c.redirect} for c in notifications]
+        noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "message": c.message, "redirect": c.redirect} for c in notifications]
     emit('get_notifications', noti_ser)
 
 
@@ -48,7 +48,7 @@ def get_notifications(user, user_data):
 ##
 def send_notifications(user):
     notifications = Notifications.query.filter_by(user = user).all()
-    noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "viewed": c.viewed, "message": c.message, "redirect": c.redirect} for c in notifications]
+    noti_ser = [{"id": c.id, "user": c.user, "type": c.type.value, "destination": c.destination, "message": c.message, "redirect": c.redirect} for c in notifications]
     emit('get_notifications', noti_ser, room= user)
 
 
@@ -76,7 +76,6 @@ def new_note(mapper, connection, new_note):
                 user = u,
                 type = NotificationType.MentionedInNote,
                 destination = new_note.id,
-                viewed = False,
                 message = create_message(NotificationType.MentionedInNote, action.title),
                 redirect = create_redirect_string(NotificationType.MentionedInNote, action.charge)
             )
@@ -99,7 +98,6 @@ def new_action(mapper, connection, new_action):
         user = new_action.assigned_to,
         type = NotificationType.AssignedToAction,
         destination = new_action.id,
-        viewed = False,
         message = create_message(NotificationType.AssignedToAction, new_action.title),
         redirect = create_redirect_string(NotificationType.AssignedToAction, new_action.charge)
     )
@@ -123,7 +121,6 @@ def new_committee(mapper, connection, new_committee):
         user = new_committee.head,
         type = NotificationType.MadeCommitteeHead,
         destination = new_committee.id,
-        viewed = False,
         message = create_message(NotificationType.MadeCommitteeHead, new_committee.title),
         redirect = create_redirect_string(NotificationType.MadeCommitteeHead, new_committee.id)
     )
@@ -147,7 +144,6 @@ def new_request(mapper, connection, new_request):
             user = new_request.committee.head,
             type = NotificationType.UserRequest,
             destination = new_request.id,
-            viewed = False,
             message = create_message(NotificationType.UserRequest, new_request.user_name),
             redirect = create_redirect_string(NotificationType.UserRequest, new_request.id)
         )

--- a/app/notifications/controllers.py
+++ b/app/notifications/controllers.py
@@ -149,27 +149,6 @@ def new_request(mapper, connection, new_request):
         )
         send_notifications(new_request.committee.head)
         
-##
-## @brief      Updates the notification when it has been viewed.
-##
-## @param      user       The user object.
-## @param      user_data  The user's token.
-##
-## @return     An array of notifications for the user.
-##
-@socketio.on('update_notification')
-@ensure_dict
-@get_user
-def update_notification(user, user_data):
-    notification = Notifications.query.filter_by(id = user_data["notificationId"]).first()
-    notification.viewed = True 
-    try:
-        db.session.commit()
-        emit('update_notification', {"success": "Notification set to viewed."})
-    except Exception as e:
-        db.session.rollback()
-        emit('update_notification', {"error": "Notification not updated correctly."})
-    return;
 
 ##
 ## @brief      Deletes the notification from the DB

--- a/app/notifications/models.py
+++ b/app/notifications/models.py
@@ -30,6 +30,5 @@ class Notifications(db.Model):
     user = db.Column(db.ForeignKey('users.id'))
     type = db.Column(ChoiceType(NotificationType, impl = db.String()))
     destination = db.Column(db.String)
-    viewed = db.Column(db.Boolean)
     message = db.Column(db.String)
     redirect = db.Column(db.String)

--- a/app/notifications/test_notifications.py
+++ b/app/notifications/test_notifications.py
@@ -154,7 +154,6 @@ class TestNotifications(object):
             'id': 1, 
             'type': 'MadeCommitteeHead',
             'user': 'testuser',
-            'viewed': False,
             'message': 'You have been made the head of the committee: testcommittee1',
             'redirect': '/committee/testcommittee1'
         }
@@ -171,7 +170,6 @@ class TestNotifications(object):
             'user': 'testuser',
             'id': 1,
             'type': 'AssignedToAction',
-            'viewed': False,
             'message': 'You have been assigned to the task: test title',
             'redirect': '/charge/10'
         }
@@ -193,7 +191,6 @@ class TestNotifications(object):
             'destination': '1',
             'type': 'UserRequest',
             'user': 'testuser',
-            'viewed': False,
             'message': 'testuser2 requests to join your committee.',
             'redirect': '/committee/1'
         }
@@ -216,7 +213,6 @@ class TestNotifications(object):
             'id': 1,
             'type': 'MentionedInNote',
             'user': 'testuser',
-            'viewed': False,
             'message': 'You have been mentioned in a note. In the task: Test Action',
             'redirect': '/charge/10'
         }


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-220

Since notifications are now going to be deleted after they are acknowledged by the user, there is no need for a `viewed` boolean. Because of this the field has been removed from the database model. There was previously an endpoint to update the notification, which set the `viewed` field to `True`. Since this field was removed, this endpoint was also removed.

No tests need to be added because the `delete_notification` functionality is unchanged and the `update_notification` functionality was removed entirely.