### PR TITLE
TT-224 - Allow meeting_day to be edited

### DIFF
--- a/app/committees/controllers.py
+++ b/app/committees/controllers.py
@@ -207,8 +207,8 @@ def edit_committee(user, user_data):
     
     for key in user_data:
 
-        if (key == "description" or key == "location" or
-            key == "meeting_time" or key == "enabled" or key == "committee_img"):
+        if (key == "description" or key == "location" or key == "meeting_day"
+            or key == "meeting_time" or key == "enabled" or key == "committee_img"):
             
             if key == "committee_img":
 

--- a/app/committees/test_committees.py
+++ b/app/committees/test_committees.py
@@ -163,8 +163,8 @@ class TestCommittees(object):
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.ComDoesntExist
 
-    # Test admin editing a committee.
-    def test_admin_edit_committee(self):
+    # Test admin editing a committee description.
+    def test_admin_edit_committee_description(self):
         db.session.add(self.test_committee)
         db.session.commit()
 
@@ -175,6 +175,58 @@ class TestCommittees(object):
         self.socketio.emit('edit_committee', edit_fields)
         received = self.socketio.get_received()
         assert received[0]["args"][0] == Response.EditSuccess
+        self.socketio.emit('get_committee', self.test_committee_dict["id"])
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["description"] == edit_fields["description"]
+
+    # Test admin editing a committee meeting day.
+    def test_admin_edit_committee_meeting_day(self):
+        db.session.add(self.test_committee)
+        db.session.commit()
+
+        edit_fields = {"token": self.admin_token,
+                       "id": self.test_committee.id,
+                       "meeting_day": 3}
+
+        self.socketio.emit('edit_committee', edit_fields)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.EditSuccess
+        self.socketio.emit('get_committee', self.test_committee_dict["id"])
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["meeting_day"] == edit_fields["meeting_day"]
+
+    
+    # Test admin editing a committee meeting time.
+    def test_admin_edit_committee_meeting_time(self):
+        db.session.add(self.test_committee)
+        db.session.commit()
+
+        edit_fields = {"token": self.admin_token,
+                       "id": self.test_committee.id,
+                       "meeting_time": "1500"}
+
+        self.socketio.emit('edit_committee', edit_fields)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.EditSuccess
+        self.socketio.emit('get_committee', self.test_committee_dict["id"])
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["meeting_time"] == edit_fields["meeting_time"]
+
+    # Test admin editing a committee location.
+    def test_admin_edit_committee_meeting_time(self):
+        db.session.add(self.test_committee)
+        db.session.commit()
+
+        edit_fields = {"token": self.admin_token,
+                       "id": self.test_committee.id,
+                       "location": "outside"}
+
+        self.socketio.emit('edit_committee', edit_fields)
+        received = self.socketio.get_received()
+        assert received[0]["args"][0] == Response.EditSuccess
+        self.socketio.emit('get_committee', self.test_committee_dict["id"])
+        received = self.socketio.get_received()
+        assert received[0]["args"][0]["location"] == edit_fields["location"]
     
     # Test admin editing a committee_head.
     def test_admin_edit_committee_head(self):

--- a/app/committees/test_committees.py
+++ b/app/committees/test_committees.py
@@ -196,7 +196,7 @@ class TestCommittees(object):
         assert received[0]["args"][0]["meeting_day"] == edit_fields["meeting_day"]
 
     
-    # Test admin editing a committee meeting time.
+    # Test admin editing a committee meeting time
     def test_admin_edit_committee_meeting_time(self):
         db.session.add(self.test_committee)
         db.session.commit()

--- a/app/committees/test_committees.py
+++ b/app/committees/test_committees.py
@@ -213,7 +213,7 @@ class TestCommittees(object):
         assert received[0]["args"][0]["meeting_time"] == edit_fields["meeting_time"]
 
     # Test admin editing a committee location.
-    def test_admin_edit_committee_meeting_time(self):
+    def test_admin_edit_committee_location(self):
         db.session.add(self.test_committee)
         db.session.commit()
 


### PR DESCRIPTION
https://ritservices.atlassian.net/browse/TT-224

Admins are able to open an edit committee modal on the frontend and edit fields such as `location` and `meeting_time`. If an admin changes the `meeting_day` field, the modal displays a success message, but if they navigate to the committee's page the change will not have taken effect. This is because the key was not being set in the backend to actually change the value.

As of the opening of this PR no additional tests have been created. There are a couple tests that test the ability of the `edit_committee` endpoint to change a committee's description, but not any other fields. It probably makes sense to include tests that ensure all of the fields get properly updated when appropriate.